### PR TITLE
Add User-Agent Support

### DIFF
--- a/analyser/main.py
+++ b/analyser/main.py
@@ -11,6 +11,7 @@ from requests import Session
 parser = ArgumentParser(description='A Web Analyser')
 parser.add_argument('-u', '--url', type=str, help='The URL')
 parser.add_argument('-o', '--output', type=str, help='The Output File')
+parser.add_argument('--user', '--user-agent', type=str, help='The User-Agent to use', default='requests')
 args = parser.parse_args()
 
 
@@ -19,6 +20,7 @@ context.url = fix_url(args.url)
 context.file = fix_filepath(args.output)
 
 context.session = Session()
+context.session.headers.update({'User-Agent': args.user})
 
 
 # Log it all


### PR DESCRIPTION
Fixes #1 

Can now specify a User-Agent using the `--user` flag.

Tested using
```python
r = context.session.get('https://www.whatismybrowser.com/detect/what-is-my-user-agent')
print(r.text.split('?analyse-my-user-agent=yes">')[1].split('</a>')[0])
```

Uses the session to get a website, reads the user-agent; has been correct so far.

Appears to work.