### PR TITLE
Ability to include cookies

### DIFF
--- a/analyser/main.py
+++ b/analyser/main.py
@@ -1,7 +1,7 @@
 import utils.context as context
 import utils.log as log
 import helpers.recon as recon
-from utils.utils import fix_url, fix_filepath
+from utils.utils import fix_url, fix_filepath, cookie_string_to_dict
 
 from argparse import ArgumentParser
 from requests import Session
@@ -12,6 +12,7 @@ parser = ArgumentParser(description='A Web Analyser')
 parser.add_argument('-u', '--url', type=str, help='The URL')
 parser.add_argument('-o', '--output', type=str, help='The Output File')
 parser.add_argument('--user', '--user-agent', type=str, help='The User-Agent to use', default='requests')
+parser.add_argument('-c', '--cookies', type=str, help='Any cookies you need')
 args = parser.parse_args()
 
 
@@ -21,6 +22,9 @@ context.file = fix_filepath(args.output)
 
 context.session = Session()
 context.session.headers.update({'User-Agent': args.user})
+
+if args.cookies:
+    context.session.cookies.update(cookie_string_to_dict(args.cookies))
 
 
 # Log it all

--- a/analyser/utils/utils.py
+++ b/analyser/utils/utils.py
@@ -59,3 +59,16 @@ def fix_filepath(file: str):
         raise EnvironmentError('The output file already exists!')
     
     return full_path
+
+
+def cookie_string_to_dict(cookies: str):
+    cookie_dict = {}
+    
+    cookies = cookies.split('; ')
+
+    for c in cookies:
+        name, value = c.split('=')
+
+        cookie_dict[name] = value
+    
+    return cookie_dict


### PR DESCRIPTION
Fixes #12 

Users can now append cookies in the form `a=b; c=d; e=f` using the `--cookies` flag. This automatically updates the `requests.Session()` for all future requests.