### PR TITLE
Username and Password supported on Basic Auth

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -14,9 +14,6 @@ def grab(file: str='', text=True):
     if r.status_code not in accept_codes:
         if file != '':
             log.fail(f'Could not grab {file} - failed with status code {r.status_code}')
-    
-    if not r:
-        return ''
 
     if text:
         return r.text

--- a/web-analyser.py
+++ b/web-analyser.py
@@ -10,11 +10,21 @@ from requests import Session, get
 
 # Arguments
 parser = ArgumentParser(description='A Web Analyser')
+
 parser.add_argument('-u', '--url', type=str, help='The URL')
+
 parser.add_argument('-o', '--output', type=str, help='The Output File')
-parser.add_argument('--user', '--user-agent', type=str, help='The User-Agent to use')
+
+parser.add_argument('--agent', type=str, help='The User-Agent to use')
 parser.add_argument('-c', '--cookies', type=str, help='Any cookies you need')
+
 parser.add_argument('--hide', '--hide-fail', help='Hide "info" logs', action='store_true')
+
+parser.add_argument('-U', '--username', type=str, help='Username (for auth)')
+parser.add_argument('-P', '--password', type=str, help='Password (for auth)')
+
+# parser.add_argument('--digest', '--digest-auth', help='Use Digest Authentication instead of Basic Authentication', action='store_true')
+
 args = parser.parse_args()
 
 
@@ -24,7 +34,7 @@ context.file = fix_filepath(args.output)
 
 context.session = Session()
 
-if args.user:
+if args.agent:
     context.session.headers.update({'User-Agent': args.user})
 
 if args.cookies:
@@ -32,6 +42,9 @@ if args.cookies:
 
 if args.hide:
     context.hide_fail = True
+
+if args.username and args.password:
+    context.session.auth = (args.username, args.password)
 
 # Log it all
 log.success(f'Analysing {context.url}')


### PR DESCRIPTION
Fixes #28 - potentially.

As per [here](https://2.python-requests.org/en/v2.8.1/user/advanced/#session-objects), the `Session` object now gets it's `auth` value set. This may not work for other types of authentication.