### PR TITLE
Reduced requests number, added option to not use User-Agents

### DIFF
--- a/helpers/recon.py
+++ b/helpers/recon.py
@@ -11,7 +11,7 @@ from colorama import Fore
 from re import findall
 from base64 import standard_b64decode
 
-def execute():
+def execute(agents: bool):
     '''The function that calls all others'''
 
     robots()
@@ -22,7 +22,9 @@ def execute():
     comments()
     urls()
     resources()
-    user_agents()
+
+    if agents:
+        user_agents()
 
 
 def robots():
@@ -38,8 +40,7 @@ def sitemap():
 
 
 def cookies():
-    r = grab(text=False)
-
+    r = context.default_req
     cookies = r.cookies.get_dict()
 
     if len(cookies) == 0:
@@ -58,7 +59,7 @@ def cookies():
 
 
 def get_jwts():
-    response = get_full_response(grab(text=False))
+    response = get_full_response(context.default_req)
 
     jwts = findall(jwt_regex, response)
 
@@ -77,9 +78,7 @@ def get_jwts():
 
 
 def redirects():
-    r = grab(text=False)
-
-    history = r.history
+    history = context.default_req.history
 
     if len(history) == 0:
         log.fail('No redirects')
@@ -98,9 +97,7 @@ def redirects():
 
 
 def comments():
-    r = grab()
-
-    soup = BeautifulSoup(r, 'html.parser')
+    soup = BeautifulSoup(context.default_req.text, 'html.parser')
     comments = soup.find_all(string=lambda text: isinstance(text, Comment))
 
     if len(comments) == 0:
@@ -114,7 +111,7 @@ def comments():
 
 
 def urls():
-    urls = findall(url_regex, grab())
+    urls = findall(url_regex, context.default_req.text)
     
     if len(urls) == 0:
         log.fail('No URLs')
@@ -127,7 +124,7 @@ def urls():
 
 
 def resources():
-    resources = findall(resource_regex, grab())
+    resources = findall(resource_regex, context.default_req.text)
     
     if len(resources) == 0:
         log.fail('No Resources')
@@ -140,7 +137,7 @@ def resources():
 
 
 def user_agents():
-    length = len(context.session.get(context.url).text)
+    length = len(context.default_req.text)
     log.info(f'Standard Response Length: {length}')
 
     for agent in user_agents_list:

--- a/utils/context.py
+++ b/utils/context.py
@@ -1,7 +1,7 @@
 url = ''
-file = None
+file = None                 # Output File
 
-session = None
+session = None              # Overarching Session() object
+default_req = None          # Standard GET request to /
 
-# whether to hide the 'fail' messages
-hide_fail = False
+hide_fail = False           # hide 'fail' messages

--- a/web-analyser.py
+++ b/web-analyser.py
@@ -2,7 +2,7 @@
 import utils.context as context
 import utils.log as log
 import helpers.recon as recon
-from utils.utils import fix_url, fix_filepath, cookie_string_to_dict
+from utils.utils import fix_url, fix_filepath, cookie_string_to_dict, grab
 
 from argparse import ArgumentParser
 from requests import Session, get
@@ -23,7 +23,7 @@ parser.add_argument('--hide', '--hide-fail', help='Hide "info" logs', action='st
 parser.add_argument('-U', '--username', type=str, help='Username (for auth)')
 parser.add_argument('-P', '--password', type=str, help='Password (for auth)')
 
-# parser.add_argument('--digest', '--digest-auth', help='Use Digest Authentication instead of Basic Authentication', action='store_true')
+parser.add_argument('--nagent', '--no-agents', help='Don\'t attempt to brute User-Agents', action='store_true')
 
 args = parser.parse_args()
 
@@ -33,6 +33,9 @@ context.url = fix_url(args.url)
 context.file = fix_filepath(args.output)
 
 context.session = Session()
+
+context.default_req = grab(text=False)
+
 
 if args.agent:
     context.session.headers.update({'User-Agent': args.user})
@@ -52,4 +55,4 @@ log.success(f'Saving output to {context.file}')
 
 
 # Execute the different modules
-recon.execute()
+recon.execute(not args.nagent)


### PR DESCRIPTION
Fixes #32 

Creates a `context.default_req` variable that then gets used by most of the [`recon`](https://github.com/ir0nstone/web-analyser/blob/0038e237d243cad65966b11a90c0cd1aa49d37bd/helpers/recon.py) class' functions.

Also implements the `--nagent`/`--no-agents` flag that stops [`recon.execute()`](https://github.com/ir0nstone/web-analyser/blob/0038e237d243cad65966b11a90c0cd1aa49d37bd/helpers/recon.py#L14) from running the [`user_agents()`](https://github.com/ir0nstone/web-analyser/blob/0038e237d243cad65966b11a90c0cd1aa49d37bd/helpers/recon.py#L142) function.