### PR TITLE
Update Absolute Path Checker

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -46,8 +46,8 @@ def fix_filepath(file: str):
     if not file:
         return
 
-    # If there is a / or \, it's probably the full path already
-    if '/' in file or '\\' in file:
+    # If it starts with C:, \ or / it's likely an absolute path
+    if file.lower().startswith('c:') or file.startswith('\\') or file.startswith('/'):
         return file
 
     full_path = join(getcwd(), file)


### PR DESCRIPTION
Fixes #37 

Now it checks if the filepath starts with `c:`, `/` or `\`. If it does, it's most likely an absolute path.